### PR TITLE
Compute moment at time of sig generation to avoid stale values

### DIFF
--- a/lib/starbucks.js
+++ b/lib/starbucks.js
@@ -19,12 +19,10 @@ class Client {
         this._httpClient = Axios.create({
             baseURL: 'https://openapi.starbucks.com/v1/'
         });
-
-        this._now = Moment().unix();
     }
 
     authenticate(username, password) {
-        const sig = signature(this.client_id, this.client_secret, this._now);
+        const sig = signature(this.client_id, this.client_secret, Moment().unix());
 
         // DEBUG
         /*console.log("Timestamp: " + this._now);


### PR DESCRIPTION
If this library is left long-running, the time used to compute the signature can go stale resulting in inability to reauthenticate.  Solution is to compute moment at time of sig generation.